### PR TITLE
Add ORM models, migrations, and CRUD layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,112 @@
-# iot_board
+# IoT Board Backend
+
+This repository contains the data access layer for an agriculture IoT board. It
+uses SQLAlchemy as the ORM, Alembic for migrations, and targets a PostgreSQL
+database by default (any SQLAlchemy-compatible database such as MySQL can also
+be used).
+
+## Project layout
+
+```
+backend/
+├── __init__.py
+├── alembic/
+│   ├── env.py
+│   ├── versions/
+│   │   └── 20240229_0001_initial.py
+│   └── alembic.ini
+├── config.py
+├── crud.py
+├── database.py
+├── models.py
+├── requirements.txt
+└── seed.py
+```
+
+## Database models
+
+| Table             | Purpose                                      | Key fields                                                                                          |
+| ----------------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `fields`          | Basic information about managed plots        | `name`, `location`, `area_hectares`, `soil_type`, `created_at`                                       |
+| `crops`           | Crops planted within a field                 | `field_id`, `name`, `variety`, `planting_date`, `growth_stage`, `expected_harvest_date`             |
+| `devices`         | IoT hardware installed on a field            | `field_id`, `name`, `device_type`, `manufacturer`, `status`, `installed_at`                         |
+| `sensor_readings` | Measurements recorded by devices             | `device_id`, `sensor_type`, `value`, `unit`, `recorded_at`, `notes`                                 |
+| `operations`      | Operational log for field/crop maintenance   | `field_id`, `crop_id`, `operation_type`, `description`, `performed_at`, `operator`                  |
+
+Relationships between entities are defined using SQLAlchemy ORM relationships
+and exposed through the convenience CRUD helpers in `backend/crud.py`. These
+functions are meant to be shared by both the administration backend and large
+screen APIs, providing a single source of truth for data access.
+
+## Getting started
+
+### 1. Create a virtual environment & install dependencies
+
+```
+python -m venv .venv
+source .venv/bin/activate
+pip install -r backend/requirements.txt
+```
+
+### 2. Configure the database connection
+
+Set the `DATABASE_URL` environment variable to point to your PostgreSQL or
+MySQL instance, e.g.
+
+```
+export DATABASE_URL=postgresql+psycopg2://iot:iot@localhost:5432/iot_board
+```
+
+Optional environment variables:
+
+- `DATABASE_ECHO`: set to `1` to enable SQL logging.
+
+### 3. Run database migrations
+
+Execute Alembic from the repository root so the `backend` package is discoverable
+by Python:
+
+The project uses Alembic for schema management. The configuration is located in
+`backend/alembic.ini` and uses the database URL from the environment.
+
+```
+alembic -c backend/alembic.ini upgrade head
+```
+
+To revert:
+
+```
+alembic -c backend/alembic.ini downgrade base
+```
+
+### 4. Load sample data (optional)
+
+```
+python -m backend.seed
+```
+
+This script inserts sample fields, crops, devices, sensor readings, and
+operations to quickly visualize data in the admin interface or dashboard.
+
+### 5. Using the CRUD helpers
+
+```
+from backend.database import session_scope
+from backend import crud
+
+with session_scope() as session:
+    fields = crud.list_fields(session)
+    first_field = crud.get_field(session, fields[0].id)
+```
+
+These helpers return ORM objects that can be serialized or further processed by
+API layers.
+
+## Development notes
+
+- The ORM models live in `backend/models.py` and can be extended with additional
+  fields or relationships as required.
+- Keep Alembic migrations in sync when the models change by running
+  `alembic revision --autogenerate -m "<message>"`.
+- Seed data is intentionally lightweight; adjust the sample payload in
+  `backend/seed.py` to match your demo needs.

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,3 @@
+"""Backend package for IoT board data platform."""
+
+__all__ = ["config", "database", "models", "crud"]

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = backend/alembic
+sqlalchemy.url = %(DATABASE_URL)s
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,72 @@
+"""Alembic environment configuration."""
+
+from __future__ import annotations
+
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from backend import models
+from backend.config import get_database_settings
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# override the sqlalchemy.url value if DATABASE_URL is set
+if database_url := os.getenv("DATABASE_URL"):
+    config.set_main_option("sqlalchemy.url", database_url)
+else:
+    config.set_main_option("sqlalchemy.url", get_database_settings().url)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+# target_metadata = None
+
+target_metadata = models.Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/versions/20240229_0001_initial.py
+++ b/backend/alembic/versions/20240229_0001_initial.py
@@ -1,0 +1,76 @@
+"""Initial database schema"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20240229_0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "fields",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("location", sa.String(length=255), nullable=False),
+        sa.Column("area_hectares", sa.Float(), nullable=True),
+        sa.Column("soil_type", sa.String(length=100), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+
+    op.create_table(
+        "crops",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("field_id", sa.Integer(), sa.ForeignKey("fields.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("variety", sa.String(length=255), nullable=True),
+        sa.Column("planting_date", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("growth_stage", sa.String(length=100), nullable=True),
+        sa.Column("expected_harvest_date", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    op.create_table(
+        "devices",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("field_id", sa.Integer(), sa.ForeignKey("fields.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("device_type", sa.String(length=100), nullable=False),
+        sa.Column("manufacturer", sa.String(length=255), nullable=True),
+        sa.Column("status", sa.String(length=50), nullable=False, server_default="active"),
+        sa.Column("installed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    op.create_table(
+        "operations",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("field_id", sa.Integer(), sa.ForeignKey("fields.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("crop_id", sa.Integer(), sa.ForeignKey("crops.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("operation_type", sa.String(length=100), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("performed_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("operator", sa.String(length=100), nullable=True),
+    )
+
+    op.create_table(
+        "sensor_readings",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("device_id", sa.Integer(), sa.ForeignKey("devices.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("sensor_type", sa.String(length=100), nullable=False),
+        sa.Column("value", sa.Numeric(10, 2), nullable=False),
+        sa.Column("unit", sa.String(length=50), nullable=False),
+        sa.Column("recorded_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("notes", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("sensor_readings")
+    op.drop_table("operations")
+    op.drop_table("devices")
+    op.drop_table("crops")
+    op.drop_table("fields")

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,32 @@
+"""Configuration helpers for database access."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class DatabaseSettings:
+    """Database connection settings.
+
+    Attributes
+    ----------
+    url:
+        Full database URL. Defaults to a local PostgreSQL database. Any SQLAlchemy
+        compatible URL is accepted.
+    echo:
+        Whether SQLAlchemy should log SQL statements.
+    future:
+        Whether to enable SQLAlchemy 2.0 style engine.
+    """
+
+    url: str = os.getenv("DATABASE_URL", "postgresql+psycopg2://iot:iot@localhost:5432/iot_board")
+    echo: bool = bool(int(os.getenv("DATABASE_ECHO", "0")))
+    future: bool = True
+
+
+def get_database_settings() -> DatabaseSettings:
+    """Return database settings loaded from environment variables."""
+
+    return DatabaseSettings()

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -1,0 +1,153 @@
+"""CRUD helpers for interacting with the ORM models."""
+
+from __future__ import annotations
+
+from typing import Any, Sequence, TypeVar
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from . import models
+
+ModelType = TypeVar("ModelType", bound=models.Base)
+
+
+def list_entities(session: Session, model: type[ModelType]) -> Sequence[ModelType]:
+    """Return all rows for the given model."""
+
+    statement = select(model)
+    return session.scalars(statement).all()
+
+
+def get_entity(session: Session, model: type[ModelType], entity_id: Any) -> ModelType | None:
+    """Return a single entity by primary key or ``None`` if it does not exist."""
+
+    return session.get(model, entity_id)
+
+
+def create_entity(session: Session, instance: ModelType) -> ModelType:
+    """Persist a new instance and return it."""
+
+    session.add(instance)
+    session.flush()
+    return instance
+
+
+def update_entity(session: Session, instance: ModelType, data: dict[str, Any]) -> ModelType:
+    """Apply ``data`` to ``instance`` and return the updated entity."""
+
+    for key, value in data.items():
+        setattr(instance, key, value)
+    session.flush()
+    return instance
+
+
+def delete_entity(session: Session, instance: ModelType) -> None:
+    """Delete an instance."""
+
+    session.delete(instance)
+    session.flush()
+
+
+# Convenience wrappers -----------------------------------------------------
+
+def create_field(session: Session, **kwargs: Any) -> models.Field:
+    return create_entity(session, models.Field(**kwargs))
+
+
+def create_crop(session: Session, **kwargs: Any) -> models.Crop:
+    return create_entity(session, models.Crop(**kwargs))
+
+
+def create_device(session: Session, **kwargs: Any) -> models.Device:
+    return create_entity(session, models.Device(**kwargs))
+
+
+def create_sensor_reading(session: Session, **kwargs: Any) -> models.SensorReading:
+    return create_entity(session, models.SensorReading(**kwargs))
+
+
+def create_operation(session: Session, **kwargs: Any) -> models.Operation:
+    return create_entity(session, models.Operation(**kwargs))
+
+
+def list_fields(session: Session) -> Sequence[models.Field]:
+    return list_entities(session, models.Field)
+
+
+def list_crops(session: Session) -> Sequence[models.Crop]:
+    return list_entities(session, models.Crop)
+
+
+def list_devices(session: Session) -> Sequence[models.Device]:
+    return list_entities(session, models.Device)
+
+
+def list_sensor_readings(session: Session) -> Sequence[models.SensorReading]:
+    return list_entities(session, models.SensorReading)
+
+
+def list_operations(session: Session) -> Sequence[models.Operation]:
+    return list_entities(session, models.Operation)
+
+
+def get_field(session: Session, entity_id: Any) -> models.Field | None:
+    return get_entity(session, models.Field, entity_id)
+
+
+def get_crop(session: Session, entity_id: Any) -> models.Crop | None:
+    return get_entity(session, models.Crop, entity_id)
+
+
+def get_device(session: Session, entity_id: Any) -> models.Device | None:
+    return get_entity(session, models.Device, entity_id)
+
+
+def get_sensor_reading(session: Session, entity_id: Any) -> models.SensorReading | None:
+    return get_entity(session, models.SensorReading, entity_id)
+
+
+def get_operation(session: Session, entity_id: Any) -> models.Operation | None:
+    return get_entity(session, models.Operation, entity_id)
+
+
+def update_field(session: Session, instance: models.Field, data: dict[str, Any]) -> models.Field:
+    return update_entity(session, instance, data)
+
+
+def update_crop(session: Session, instance: models.Crop, data: dict[str, Any]) -> models.Crop:
+    return update_entity(session, instance, data)
+
+
+def update_device(session: Session, instance: models.Device, data: dict[str, Any]) -> models.Device:
+    return update_entity(session, instance, data)
+
+
+def update_sensor_reading(
+    session: Session, instance: models.SensorReading, data: dict[str, Any]
+) -> models.SensorReading:
+    return update_entity(session, instance, data)
+
+
+def update_operation(session: Session, instance: models.Operation, data: dict[str, Any]) -> models.Operation:
+    return update_entity(session, instance, data)
+
+
+def delete_field(session: Session, instance: models.Field) -> None:
+    delete_entity(session, instance)
+
+
+def delete_crop(session: Session, instance: models.Crop) -> None:
+    delete_entity(session, instance)
+
+
+def delete_device(session: Session, instance: models.Device) -> None:
+    delete_entity(session, instance)
+
+
+def delete_sensor_reading(session: Session, instance: models.SensorReading) -> None:
+    delete_entity(session, instance)
+
+
+def delete_operation(session: Session, instance: models.Operation) -> None:
+    delete_entity(session, instance)

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,30 @@
+"""Database session and engine management."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from .config import get_database_settings
+
+settings = get_database_settings()
+engine = create_engine(settings.url, echo=settings.echo, future=settings.future)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+
+@contextmanager
+def session_scope() -> Generator[Session, None, None]:
+    """Provide a transactional scope around a series of operations."""
+
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:  # pragma: no cover - safeguard for session usage
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,108 @@
+"""SQLAlchemy models describing the IoT agriculture domain."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, Numeric, String, Text, func
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+
+class Base(DeclarativeBase):
+    """Base declarative class for all ORM models."""
+
+
+class Field(Base):
+    """Represents a specific field/plot under management."""
+
+    __tablename__ = "fields"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    location: Mapped[str] = mapped_column(String(255), nullable=False)
+    area_hectares: Mapped[float] = mapped_column(Float, nullable=True)
+    soil_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    crops: Mapped[list["Crop"]] = relationship("Crop", back_populates="field", cascade="all, delete-orphan")
+    devices: Mapped[list["Device"]] = relationship(
+        "Device", back_populates="field", cascade="all, delete-orphan"
+    )
+    operations: Mapped[list["Operation"]] = relationship(
+        "Operation", back_populates="field", cascade="all, delete-orphan"
+    )
+
+
+class Crop(Base):
+    """Represents a crop planted in a field."""
+
+    __tablename__ = "crops"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    field_id: Mapped[int] = mapped_column(ForeignKey("fields.id", ondelete="CASCADE"), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    variety: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    planting_date: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    growth_stage: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    expected_harvest_date: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    field: Mapped[Field] = relationship("Field", back_populates="crops")
+    operations: Mapped[list["Operation"]] = relationship("Operation", back_populates="crop")
+
+
+class Device(Base):
+    """Represents an IoT device installed in a field."""
+
+    __tablename__ = "devices"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    field_id: Mapped[int] = mapped_column(ForeignKey("fields.id", ondelete="SET NULL"), nullable=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    device_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    manufacturer: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    status: Mapped[str] = mapped_column(String(50), nullable=False, default="active")
+    installed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    field: Mapped[Field | None] = relationship("Field", back_populates="devices")
+    sensor_readings: Mapped[list["SensorReading"]] = relationship(
+        "SensorReading", back_populates="device", cascade="all, delete-orphan"
+    )
+
+
+class SensorReading(Base):
+    """Represents a sensor reading from a device."""
+
+    __tablename__ = "sensor_readings"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    device_id: Mapped[int] = mapped_column(ForeignKey("devices.id", ondelete="CASCADE"), nullable=False)
+    sensor_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    value: Mapped[float] = mapped_column(Numeric(10, 2), nullable=False)
+    unit: Mapped[str] = mapped_column(String(50), nullable=False)
+    recorded_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    device: Mapped[Device] = relationship("Device", back_populates="sensor_readings")
+
+
+class Operation(Base):
+    """Represents an operation performed on a field/crop."""
+
+    __tablename__ = "operations"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    field_id: Mapped[int] = mapped_column(ForeignKey("fields.id", ondelete="SET NULL"), nullable=True)
+    crop_id: Mapped[int | None] = mapped_column(ForeignKey("crops.id", ondelete="SET NULL"), nullable=True)
+    operation_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    performed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    operator: Mapped[str | None] = mapped_column(String(100), nullable=True)
+
+    field: Mapped[Field | None] = relationship("Field", back_populates="operations")
+    crop: Mapped[Crop | None] = relationship("Crop", back_populates="operations")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+SQLAlchemy>=2.0
+alembic>=1.13
+psycopg2-binary>=2.9

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -1,0 +1,101 @@
+"""Seed script to populate the database with sample data."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from .database import session_scope
+from . import crud
+
+
+SAMPLE_DATA = {
+    "fields": [
+        {
+            "name": "North Field",
+            "location": "POINT(120.15 30.28)",
+            "area_hectares": 5.5,
+            "soil_type": "Loam",
+        },
+        {
+            "name": "South Field",
+            "location": "POINT(120.16 30.27)",
+            "area_hectares": 3.2,
+            "soil_type": "Clay",
+        },
+    ],
+    "crops": [
+        {
+            "field_index": 0,
+            "name": "Rice",
+            "variety": "Japonica",
+            "planting_date": datetime.utcnow() - timedelta(days=60),
+            "growth_stage": "Vegetative",
+        },
+        {
+            "field_index": 1,
+            "name": "Corn",
+            "variety": "Sweet",
+            "planting_date": datetime.utcnow() - timedelta(days=30),
+            "growth_stage": "Seedling",
+        },
+    ],
+    "devices": [
+        {
+            "field_index": 0,
+            "name": "Weather Station",
+            "device_type": "weather",
+            "manufacturer": "Acme",
+            "status": "active",
+        },
+        {
+            "field_index": 1,
+            "name": "Soil Probe",
+            "device_type": "soil",
+            "manufacturer": "GreenTech",
+            "status": "active",
+        },
+    ],
+}
+
+
+def seed() -> None:
+    """Insert sample data for quick demos."""
+
+    with session_scope() as session:
+        fields = [crud.create_field(session, **field) for field in SAMPLE_DATA["fields"]]
+
+        crops = []
+        for crop in SAMPLE_DATA["crops"]:
+            payload = crop.copy()
+            field_index = payload.pop("field_index")
+            payload["field_id"] = fields[field_index].id
+            crops.append(crud.create_crop(session, **payload))
+
+        devices = []
+        for device in SAMPLE_DATA["devices"]:
+            payload = device.copy()
+            field_index = payload.pop("field_index")
+            payload["field_id"] = fields[field_index].id
+            devices.append(crud.create_device(session, **payload))
+
+        if devices:
+            crud.create_sensor_reading(
+                session,
+                device_id=devices[0].id,
+                sensor_type="temperature",
+                value=24.5,
+                unit="°C",
+            )
+
+        if fields and crops:
+            crud.create_operation(
+                session,
+                field_id=fields[0].id,
+                crop_id=crops[0].id,
+                operation_type="Fertilization",
+                description="Applied nitrogen fertilizer",
+            )
+
+
+if __name__ == "__main__":
+    seed()


### PR DESCRIPTION
## Summary
- scaffold a backend package with SQLAlchemy configuration, ORM models, and CRUD helpers for fields, crops, devices, sensor readings, and operations
- add Alembic configuration with an initial migration and seed script plus Python dependencies
- document the database schema, migration commands, and setup steps in the README

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68cd07e8b62c8321bbbd551fa4f63097