### PR TITLE
Implement realtime IoT dashboard stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.py[cod]
+*.sqlite3
+*.db
+.env
+.venv/
+backend/.venv/
+backend/iot_board.db
+node_modules/
+frontend/node_modules/
+frontend/dist/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# iot_board
+# IoT Board
+
+This repository contains a demo IoT command center with a FastAPI backend and a React dashboard. The backend exposes REST, WebSocket and Server-Sent Event (SSE) interfaces that push real-time updates to the dashboard. A simulation mode periodically generates environmental readings, device status changes and alarm events so the entire stack can be demonstrated without connecting to real devices.
+
+## Backend
+
+The backend lives in [`backend/`](backend/) and is built with FastAPI. It exposes REST endpoints under `/api` for querying recent data and provides a WebSocket endpoint at `/api/ws` plus an SSE stream at `/api/events`. A background scheduler ingests incoming payloads, persists them to SQLite and broadcasts the events to connected clients.
+
+### Running the backend
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+Environment variables prefixed with `IOT_BOARD_` can be used to override configuration, for example `IOT_BOARD_SIMULATION_MODE=false` to disable the synthetic data generator.
+
+## Frontend
+
+The frontend lives in [`frontend/`](frontend/) and is a small Vite + React project. It uses a dedicated realtime service (`src/services/realtime.ts`) that handles WebSocket lifecycles, automatic reconnection and SSE fallback. Dashboard widgets subscribe to relevant events and refresh themselves instantly when new payloads arrive.
+
+### Running the frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The dev server proxies API calls to `http://localhost:8000` by default.
+
+## Development notes
+
+* When the backend starts, a simulation worker pushes demo data every few seconds. This keeps the dashboard lively in demos.
+* The backend uses SQLite via SQLAlchemy's async engine. Database schema is created automatically on startup.
+* Realtime broadcasts are logged in the `realtime_dispatch_log` table for traceability.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,5 @@
+"""IoT Board backend application package."""
+
+from .main import create_app
+
+__all__ = ["create_app"]

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,43 @@
+"""Configuration helpers for the IoT Board backend."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Literal
+
+from pydantic import BaseSettings, Field
+
+
+class Settings(BaseSettings):
+    """Runtime configuration loaded from environment variables."""
+
+    database_url: str = Field(
+        default="sqlite+aiosqlite:///./iot_board.db",
+        description="SQLAlchemy compatible database URL.",
+    )
+    simulation_mode: bool = Field(
+        default=True,
+        description="Enable synthetic data generation for demos and tests.",
+    )
+    simulation_interval_seconds: float = Field(
+        default=2.0,
+        description="Interval for pushing synthetic data when simulation mode is enabled.",
+    )
+    realtime_channel: Literal["websocket", "sse"] = Field(
+        default="websocket",
+        description="Preferred realtime push channel type.",
+    )
+
+    class Config:
+        env_prefix = "IOT_BOARD_"
+        case_sensitive = False
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return a cached settings instance."""
+
+    return Settings()
+
+
+__all__ = ["Settings", "get_settings"]

--- a/backend/app/data_ingestion.py
+++ b/backend/app/data_ingestion.py
@@ -1,0 +1,178 @@
+"""Data ingestion utilities for pushing IoT updates into the system."""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from datetime import datetime
+from typing import Awaitable, Callable
+
+from sqlalchemy import select
+
+from .config import get_settings
+from .db import get_async_session
+from .models import AlarmEvent, DeviceStatus, EnvironmentReading, RealTimeDispatchLog
+from .realtime import manager
+from .schemas import BroadcastEnvelope
+
+
+async def upsert_device_status(
+    device_id: str, name: str, status: str, meta: dict | None = None
+) -> DeviceStatus:
+    meta = meta or {}
+    async with get_async_session() as session:
+        stmt = select(DeviceStatus).where(DeviceStatus.device_id == device_id)
+        result = await session.execute(stmt)
+        instance = result.scalar_one_or_none()
+        if instance is None:
+            instance = DeviceStatus(device_id=device_id, name=name, status=status, meta=meta)
+            session.add(instance)
+        else:
+            instance.status = status
+            instance.meta = meta
+        instance.updated_at = datetime.utcnow()
+        await session.commit()
+        await session.refresh(instance)
+    return instance
+
+
+async def create_environment_reading(**kwargs) -> EnvironmentReading:
+    async with get_async_session() as session:
+        reading = EnvironmentReading(**kwargs)
+        session.add(reading)
+        await session.commit()
+        await session.refresh(reading)
+    return reading
+
+
+async def create_alarm_event(**kwargs) -> AlarmEvent:
+    async with get_async_session() as session:
+        alarm = AlarmEvent(**kwargs)
+        session.add(alarm)
+        await session.commit()
+        await session.refresh(alarm)
+    return alarm
+
+
+async def persist_and_broadcast(event: str, payload: dict) -> None:
+    envelope = BroadcastEnvelope(event=event, payload=payload)
+    async with get_async_session() as session:
+        session.add(RealTimeDispatchLog(event_type=event, payload=payload))
+        await session.commit()
+    await manager.broadcast(envelope)
+
+
+async def handle_environment_update(data: dict) -> None:
+    reading = await create_environment_reading(**data)
+    await persist_and_broadcast(
+        "environment.update",
+        {
+            "id": reading.id,
+            "location": reading.location,
+            "temperature": reading.temperature,
+            "humidity": reading.humidity,
+            "air_quality_index": reading.air_quality_index,
+            "created_at": reading.created_at.isoformat(),
+        },
+    )
+
+
+async def handle_device_status(data: dict) -> None:
+    status = await upsert_device_status(**data)
+    await persist_and_broadcast(
+        "device.update",
+        {
+            "id": status.id,
+            "device_id": status.device_id,
+            "name": status.name,
+            "status": status.status,
+            "meta": status.meta,
+            "updated_at": status.updated_at.isoformat(),
+        },
+    )
+
+
+async def handle_alarm(data: dict) -> None:
+    alarm = await create_alarm_event(**data)
+    await persist_and_broadcast(
+        "alarm.raise",
+        {
+            "id": alarm.id,
+            "code": alarm.code,
+            "message": alarm.message,
+            "severity": alarm.severity,
+            "device_id": alarm.device_id,
+            "created_at": alarm.created_at.isoformat(),
+        },
+    )
+
+
+async def simulation_worker(stop_event: asyncio.Event) -> None:
+    """Periodically generate demo payloads when simulation mode is enabled."""
+
+    settings = get_settings()
+    interval = settings.simulation_interval_seconds
+    counter = 0
+    while not stop_event.is_set():
+        await asyncio.sleep(interval)
+        counter += 1
+        temperature = round(20 + random.random() * 5, 2)
+        humidity = round(40 + random.random() * 20, 2)
+        aqi = round(50 + random.random() * 20, 2)
+        await handle_environment_update(
+            {
+                "location": "demo",
+                "temperature": temperature,
+                "humidity": humidity,
+                "air_quality_index": aqi,
+            }
+        )
+        status = random.choice(["online", "offline", "maintenance"])
+        await handle_device_status(
+            {
+                "device_id": "demo-device",
+                "name": "Demo Sensor",
+                "status": status,
+                "meta": {"iteration": counter},
+            }
+        )
+        if status == "offline":
+            await handle_alarm(
+                {
+                    "code": "DEVICE_OFFLINE",
+                    "message": "Demo sensor lost connectivity",
+                    "severity": "warning",
+                    "device_id": "demo-device",
+                }
+            )
+
+
+async def start_background_tasks() -> Callable[[], Awaitable[None]]:
+    """Launch data listeners and return a shutdown callback."""
+
+    settings = get_settings()
+    stop_event = asyncio.Event()
+    tasks = []
+
+    if settings.simulation_mode:
+        tasks.append(asyncio.create_task(simulation_worker(stop_event)))
+
+    async def shutdown() -> None:
+        stop_event.set()
+        for task in tasks:
+            task.cancel()
+        for task in tasks:
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    return shutdown
+
+
+__all__ = [
+    "handle_environment_update",
+    "handle_device_status",
+    "handle_alarm",
+    "start_background_tasks",
+]

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,0 +1,76 @@
+"""Database utilities for the IoT board backend."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, Callable
+
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.orm import DeclarativeBase
+
+from .config import get_settings
+
+
+class Base(DeclarativeBase):
+    """Declarative base class for ORM models."""
+
+
+_engine: AsyncEngine | None = None
+_session_factory: async_sessionmaker[AsyncSession] | None = None
+
+
+def get_engine() -> AsyncEngine:
+    """Return a lazily initialised async engine."""
+
+    global _engine
+    if _engine is None:
+        settings = get_settings()
+        _engine = create_async_engine(settings.database_url, echo=False)
+    return _engine
+
+
+def get_session_factory() -> async_sessionmaker[AsyncSession]:
+    """Return the shared async session factory."""
+
+    global _session_factory
+    if _session_factory is None:
+        _session_factory = async_sessionmaker(get_engine(), expire_on_commit=False)
+    return _session_factory
+
+
+@asynccontextmanager
+async def get_async_session() -> AsyncIterator[AsyncSession]:
+    """Provide a transactional scope around a series of operations."""
+
+    factory = get_session_factory()
+    async with factory() as session:
+        yield session
+
+
+async def run_in_session(callback: Callable[[AsyncSession], AsyncIterator[None] | None]) -> None:
+    """Helper to run an async callback within a session, committing afterwards."""
+
+    async with get_async_session() as session:
+        try:
+            result = callback(session)
+            if result is not None and hasattr(result, "__aiter__"):
+                async for _ in result:  # pragma: no cover - convenience for async generators
+                    pass
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+
+__all__ = [
+    "Base",
+    "get_engine",
+    "get_session_factory",
+    "get_async_session",
+    "run_in_session",
+]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,47 @@
+"""FastAPI application entrypoint for the IoT board backend."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from .config import get_settings
+from .data_ingestion import start_background_tasks
+from .db import Base, get_engine
+from .routes import router
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    engine = get_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    shutdown_callback = await start_background_tasks()
+    try:
+        yield
+    finally:
+        await shutdown_callback()
+
+
+def create_app() -> FastAPI:
+    settings = get_settings()
+    app = FastAPI(title="IoT Board Backend", lifespan=lifespan)
+    app.include_router(router, prefix="/api")
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    app.state.settings = settings
+    return app
+
+
+app = create_app()
+
+
+__all__ = ["create_app", "app"]

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,69 @@
+"""Database models for IoT board entities."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, Float, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .db import Base
+
+
+class EnvironmentReading(Base):
+    """Stores environmental sensor values such as temperature and humidity."""
+
+    __tablename__ = "environment_readings"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    location: Mapped[str] = mapped_column(String(64), default="default")
+    temperature: Mapped[float] = mapped_column(Float)
+    humidity: Mapped[float] = mapped_column(Float)
+    air_quality_index: Mapped[float] = mapped_column(Float)
+    created_at: Mapped[datetime] = mapped_column(default=datetime.utcnow, index=True)
+
+
+class DeviceStatus(Base):
+    """Represents the current state of an IoT device."""
+
+    __tablename__ = "device_statuses"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    device_id: Mapped[str] = mapped_column(String(64), unique=True, index=True)
+    name: Mapped[str] = mapped_column(String(128))
+    status: Mapped[str] = mapped_column(String(32))
+    meta: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
+    updated_at: Mapped[datetime] = mapped_column(default=datetime.utcnow, index=True)
+
+
+class AlarmEvent(Base):
+    """High priority alerts that should be surfaced immediately."""
+
+    __tablename__ = "alarm_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    code: Mapped[str] = mapped_column(String(32), index=True)
+    message: Mapped[str] = mapped_column(String(255))
+    severity: Mapped[str] = mapped_column(String(16), default="info")
+    created_at: Mapped[datetime] = mapped_column(default=datetime.utcnow, index=True)
+    device_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+
+class RealTimeDispatchLog(Base):
+    """Optional log of broadcasted payloads for auditing."""
+
+    __tablename__ = "realtime_dispatch_log"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    event_type: Mapped[str] = mapped_column(String(32), index=True)
+    payload: Mapped[dict[str, Any]] = mapped_column(JSON)
+    created_at: Mapped[datetime] = mapped_column(default=datetime.utcnow, index=True)
+
+
+__all__ = [
+    "EnvironmentReading",
+    "DeviceStatus",
+    "AlarmEvent",
+    "RealTimeDispatchLog",
+]

--- a/backend/app/realtime.py
+++ b/backend/app/realtime.py
@@ -1,0 +1,75 @@
+"""Realtime channel manager supporting WebSocket and SSE clients."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import AsyncIterator, Dict, Iterable
+
+from fastapi import WebSocket
+from fastapi.responses import EventSourceResponse
+
+from .schemas import BroadcastEnvelope
+
+class RealtimeChannelManager:
+    """Keeps track of active realtime connections and pushes broadcast events."""
+
+    def __init__(self) -> None:
+        self._websockets: set[WebSocket] = set()
+        self._sse_queues: Dict[int, asyncio.Queue[str]] = {}
+        self._lock = asyncio.Lock()
+
+    async def register_websocket(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        async with self._lock:
+            self._websockets.add(websocket)
+
+    async def unregister_websocket(self, websocket: WebSocket) -> None:
+        async with self._lock:
+            self._websockets.discard(websocket)
+
+    async def register_sse(self) -> AsyncIterator[Iterable[str]]:
+        queue: asyncio.Queue[str] = asyncio.Queue()
+        ident = id(queue)
+        async with self._lock:
+            self._sse_queues[ident] = queue
+
+        try:
+            while True:
+                payload = await queue.get()
+                yield payload
+        finally:
+            async with self._lock:
+                self._sse_queues.pop(ident, None)
+
+    async def broadcast(self, envelope: BroadcastEnvelope) -> None:
+        data = envelope.model_dump()
+        payload = json.dumps(data, default=str)
+        async with self._lock:
+            websockets = list(self._websockets)
+            queues = list(self._sse_queues.values())
+
+        coroutines = [ws.send_text(payload) for ws in websockets]
+        if coroutines:
+            await asyncio.gather(*coroutines, return_exceptions=True)
+
+        for queue in queues:
+            await queue.put(f"data: {payload}\n\n")
+
+    async def emit(self, event: str, payload: dict) -> None:
+        envelope = BroadcastEnvelope(event=event, payload=payload)
+        await self.broadcast(envelope)
+
+
+manager = RealtimeChannelManager()
+
+
+async def sse_endpoint() -> EventSourceResponse:
+    async def event_publisher():
+        async for payload in manager.register_sse():
+            yield payload
+
+    return EventSourceResponse(event_publisher())
+
+
+__all__ = ["RealtimeChannelManager", "manager", "sse_endpoint"]

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,0 +1,94 @@
+"""API routes for IoT board backend."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from sqlalchemy import select
+
+from .data_ingestion import (
+    handle_alarm,
+    handle_device_status,
+    handle_environment_update,
+)
+from .db import get_async_session
+from .models import AlarmEvent, DeviceStatus, EnvironmentReading
+from .realtime import manager, sse_endpoint
+from .schemas import (
+    AlarmEventIn,
+    AlarmEventOut,
+    DeviceStatusIn,
+    DeviceStatusOut,
+    EnvironmentReadingIn,
+    EnvironmentReadingOut,
+)
+
+router = APIRouter()
+
+
+@router.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket) -> None:
+    await manager.register_websocket(websocket)
+    try:
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        await manager.unregister_websocket(websocket)
+
+
+@router.get("/events")
+async def events_stream():
+    return await sse_endpoint()
+
+
+@router.post("/environment", response_model=EnvironmentReadingOut)
+async def post_environment_reading(payload: EnvironmentReadingIn):
+    await handle_environment_update(payload.model_dump())
+    async with get_async_session() as session:
+        stmt = select(EnvironmentReading).order_by(EnvironmentReading.id.desc())
+        result = await session.execute(stmt)
+        return result.scalars().first()
+
+
+@router.get("/environment", response_model=list[EnvironmentReadingOut])
+async def list_environment_readings(limit: int = 20):
+    async with get_async_session() as session:
+        stmt = select(EnvironmentReading).order_by(EnvironmentReading.created_at.desc()).limit(limit)
+        result = await session.execute(stmt)
+        return list(result.scalars())
+
+
+@router.post("/devices", response_model=DeviceStatusOut)
+async def post_device_status(payload: DeviceStatusIn):
+    await handle_device_status(payload.model_dump())
+    async with get_async_session() as session:
+        stmt = select(DeviceStatus).where(DeviceStatus.device_id == payload.device_id)
+        result = await session.execute(stmt)
+        return result.scalar_one()
+
+
+@router.get("/devices", response_model=list[DeviceStatusOut])
+async def list_devices():
+    async with get_async_session() as session:
+        stmt = select(DeviceStatus)
+        result = await session.execute(stmt)
+        return list(result.scalars())
+
+
+@router.post("/alarms", response_model=AlarmEventOut)
+async def post_alarm(payload: AlarmEventIn):
+    await handle_alarm(payload.model_dump())
+    async with get_async_session() as session:
+        stmt = select(AlarmEvent).order_by(AlarmEvent.id.desc())
+        result = await session.execute(stmt)
+        return result.scalars().first()
+
+
+@router.get("/alarms", response_model=list[AlarmEventOut])
+async def list_alarms(limit: int = 20):
+    async with get_async_session() as session:
+        stmt = select(AlarmEvent).order_by(AlarmEvent.created_at.desc()).limit(limit)
+        result = await session.execute(stmt)
+        return list(result.scalars())
+
+
+__all__ = ["router"]

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,66 @@
+"""Pydantic schemas for API payloads."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class EnvironmentReadingIn(BaseModel):
+    location: str = Field(default="default")
+    temperature: float
+    humidity: float
+    air_quality_index: float = Field(alias="aqi")
+
+    class Config:
+        populate_by_name = True
+
+
+class EnvironmentReadingOut(EnvironmentReadingIn):
+    id: int
+    created_at: datetime
+
+
+class DeviceStatusIn(BaseModel):
+    device_id: str
+    name: str
+    status: Literal["online", "offline", "maintenance", "error", "warning"]
+    meta: dict[str, Any] = Field(default_factory=dict)
+
+
+class DeviceStatusOut(DeviceStatusIn):
+    id: int
+    updated_at: datetime
+
+
+class AlarmEventIn(BaseModel):
+    code: str
+    message: str
+    severity: Literal["info", "warning", "critical"]
+    device_id: str | None = None
+
+
+class AlarmEventOut(AlarmEventIn):
+    id: int
+    created_at: datetime
+
+
+class BroadcastEnvelope(BaseModel):
+    """Common structure used for data pushed to realtime channels."""
+
+    event: str
+    payload: dict[str, Any]
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+__all__ = [
+    "EnvironmentReadingIn",
+    "EnvironmentReadingOut",
+    "DeviceStatusIn",
+    "DeviceStatusOut",
+    "AlarmEventIn",
+    "AlarmEventOut",
+    "BroadcastEnvelope",
+]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.111.0
+uvicorn[standard]==0.29.0
+sqlalchemy[asyncio]==2.0.30
+aiosqlite==0.20.0
+pydantic-settings==2.3.0
+python-multipart==0.0.9

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>IoT Board Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "iot-board",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "mitt": "^3.0.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.22",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.2.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.2.0"
+  }
+}

--- a/frontend/src/components/AlarmPanel.tsx
+++ b/frontend/src/components/AlarmPanel.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import realtimeService from "../services/realtime";
+import { AlarmEvent } from "../types/realtime";
+
+interface Props {
+  initialAlarms?: AlarmEvent[];
+}
+
+export default function AlarmPanel({ initialAlarms = [] }: Props) {
+  const [alarms, setAlarms] = useState<AlarmEvent[]>(initialAlarms);
+
+  useEffect(() => {
+    setAlarms(initialAlarms);
+  }, [initialAlarms]);
+
+  useEffect(() => {
+    const unsubscribe = realtimeService.on("alarm.raise", (payload) => {
+      setAlarms((prev) => [payload as AlarmEvent, ...prev].slice(0, 20));
+    });
+    return () => unsubscribe();
+  }, []);
+
+  return (
+    <section className="card">
+      <header className="card__header">
+        <h2>Alarms</h2>
+      </header>
+      <div className="card__body alarm-list">
+        {alarms.length === 0 && <div>No alarms</div>}
+        {alarms.map((alarm) => (
+          <div key={alarm.id} className={`alarm alarm--${alarm.severity}`}>
+            <div className="alarm__title">{alarm.code}</div>
+            <div className="alarm__message">{alarm.message}</div>
+            <div className="alarm__time">{new Date(alarm.created_at).toLocaleTimeString()}</div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/DeviceStatusBoard.tsx
+++ b/frontend/src/components/DeviceStatusBoard.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import realtimeService from "../services/realtime";
+import { DeviceStatus } from "../types/realtime";
+
+interface Props {
+  initialDevices?: DeviceStatus[];
+}
+
+function statusColor(status: string) {
+  switch (status) {
+    case "online":
+      return "status--success";
+    case "offline":
+      return "status--danger";
+    case "maintenance":
+      return "status--warning";
+    default:
+      return "status--info";
+  }
+}
+
+export default function DeviceStatusBoard({ initialDevices = [] }: Props) {
+  const [devices, setDevices] = useState<Record<string, DeviceStatus>>(() => {
+    const map: Record<string, DeviceStatus> = {};
+    initialDevices.forEach((device) => {
+      map[device.device_id] = device;
+    });
+    return map;
+  });
+
+  const deviceList = Object.values(devices);
+
+  useEffect(() => {
+    const map: Record<string, DeviceStatus> = {};
+    initialDevices.forEach((device) => {
+      map[device.device_id] = device;
+    });
+    setDevices(map);
+  }, [initialDevices]);
+
+  useEffect(() => {
+    const unsubscribe = realtimeService.on("device.update", (payload) => {
+      const device = payload as DeviceStatus;
+      setDevices((prev) => ({
+        ...prev,
+        [device.device_id]: device,
+      }));
+    });
+    return () => unsubscribe();
+  }, []);
+
+  return (
+    <section className="card">
+      <header className="card__header">
+        <h2>Devices</h2>
+      </header>
+      <div className="card__body device-list">
+        {deviceList.length === 0 && <div>No devices yet</div>}
+        {deviceList.map((device) => (
+          <div key={device.device_id} className={`device ${statusColor(device.status)}`}>
+            <div className="device__name">{device.name}</div>
+            <div className="device__status">{device.status}</div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/EnvironmentMonitor.tsx
+++ b/frontend/src/components/EnvironmentMonitor.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+import realtimeService from "../services/realtime";
+import { EnvironmentReading } from "../types/realtime";
+
+interface Props {
+  initialReadings?: EnvironmentReading[];
+}
+
+export default function EnvironmentMonitor({ initialReadings = [] }: Props) {
+  const [readings, setReadings] = useState<EnvironmentReading[]>(initialReadings);
+
+  useEffect(() => {
+    setReadings(initialReadings);
+  }, [initialReadings]);
+
+  useEffect(() => {
+    const unsubscribe = realtimeService.on("environment.update", (payload) => {
+      setReadings((prev) => {
+        const next = [payload as EnvironmentReading, ...prev];
+        return next.slice(0, 10);
+      });
+    });
+    return () => unsubscribe();
+  }, []);
+
+  const latest = readings[0];
+
+  return (
+    <section className="card">
+      <header className="card__header">
+        <h2>Environment</h2>
+      </header>
+      {latest ? (
+        <div className="card__body">
+          <div className="metric">
+            <span className="metric__label">Temperature</span>
+            <span className="metric__value">{latest.temperature.toFixed(1)}°C</span>
+          </div>
+          <div className="metric">
+            <span className="metric__label">Humidity</span>
+            <span className="metric__value">{latest.humidity.toFixed(1)}%</span>
+          </div>
+          <div className="metric">
+            <span className="metric__label">AQI</span>
+            <span className="metric__value">{latest.air_quality_index.toFixed(0)}</span>
+          </div>
+        </div>
+      ) : (
+        <div className="card__body">No data yet</div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import DashboardPage from "./pages/Dashboard";
+import "./styles.css";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <DashboardPage />
+  </React.StrictMode>
+);

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react";
+import AlarmPanel from "../components/AlarmPanel";
+import DeviceStatusBoard from "../components/DeviceStatusBoard";
+import EnvironmentMonitor from "../components/EnvironmentMonitor";
+import realtimeService from "../services/realtime";
+import { AlarmEvent, DeviceStatus, EnvironmentReading } from "../types/realtime";
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}`);
+  }
+  return response.json();
+}
+
+export default function DashboardPage() {
+  const [environment, setEnvironment] = useState<EnvironmentReading[]>([]);
+  const [devices, setDevices] = useState<DeviceStatus[]>([]);
+  const [alarms, setAlarms] = useState<AlarmEvent[]>([]);
+  const [connected, setConnected] = useState(false);
+
+  useEffect(() => {
+    Promise.all([
+      fetchJson<EnvironmentReading[]>("/api/environment"),
+      fetchJson<DeviceStatus[]>("/api/devices"),
+      fetchJson<AlarmEvent[]>("/api/alarms"),
+    ])
+      .then(([envData, deviceData, alarmData]) => {
+        setEnvironment(envData);
+        setDevices(deviceData);
+        setAlarms(alarmData);
+      })
+      .catch((error) => console.error(error));
+  }, []);
+
+  useEffect(() => {
+    const handleOpen = () => setConnected(true);
+    const handleClose = () => setConnected(false);
+    const offOpen = realtimeService.onOpen(handleOpen);
+    const offClose = realtimeService.onClose(handleClose);
+    const offError = realtimeService.onError(() => setConnected(false));
+    return () => {
+      offOpen();
+      offClose();
+      offError();
+    };
+  }, []);
+
+  return (
+    <main className="dashboard">
+      <header className="dashboard__header">
+        <h1>IoT Command Center</h1>
+        <div className={`status-indicator ${connected ? "is-online" : "is-offline"}`}>
+          {connected ? "Realtime Connected" : "Connecting..."}
+        </div>
+      </header>
+      <div className="dashboard__grid">
+        <EnvironmentMonitor initialReadings={environment} />
+        <DeviceStatusBoard initialDevices={devices} />
+        <AlarmPanel initialAlarms={alarms} />
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/services/realtime.ts
+++ b/frontend/src/services/realtime.ts
@@ -1,0 +1,202 @@
+import mitt, { Emitter, Handler } from "mitt";
+
+type RealtimeEvents = {
+  message: any;
+  open: Event;
+  close: CloseEvent;
+  error: Event;
+};
+
+type Listener = (payload: any) => void;
+
+type EventMap = Record<string, Set<Listener>>;
+
+const DEFAULT_ENDPOINT = "/api/ws";
+const RECONNECT_INTERVAL = 3000;
+
+export class RealtimeService {
+  private socket: WebSocket | null = null;
+  private emitter: Emitter<RealtimeEvents> = mitt<RealtimeEvents>();
+  private eventMap: EventMap = {};
+  private url: string;
+  private reconnectTimer: number | null = null;
+  private manualClose = false;
+  private eventSource: EventSource | null = null;
+  private failureCount = 0;
+  private useSse = false;
+
+  constructor(endpoint: string = DEFAULT_ENDPOINT) {
+    this.url = this.resolveUrl(endpoint);
+    this.connect();
+  }
+
+  private resolveUrl(endpoint: string): string {
+    if (endpoint.startsWith("ws")) {
+      return endpoint;
+    }
+    const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+    const host = window.location.host;
+    return `${protocol}://${host}${endpoint}`;
+  }
+
+  private connect() {
+    this.manualClose = false;
+    if (this.useSse) {
+      this.openSse();
+      return;
+    }
+    this.socket = new WebSocket(this.url);
+    this.socket.onopen = (event) => {
+      if (this.reconnectTimer) {
+        window.clearTimeout(this.reconnectTimer);
+        this.reconnectTimer = null;
+      }
+      this.failureCount = 0;
+      this.emitter.emit("open", event);
+    };
+    this.socket.onclose = (event) => {
+      this.emitter.emit("close", event);
+      this.socket = null;
+      if (!this.manualClose) {
+        this.scheduleReconnect();
+      }
+    };
+    this.socket.onerror = (event) => {
+      this.emitter.emit("error", event);
+      this.failureCount += 1;
+    };
+    this.socket.onmessage = (event) => {
+      try {
+        const payload = JSON.parse(event.data);
+        this.emitter.emit("message", payload);
+        this.dispatchEvent(payload.event, payload.payload);
+      } catch (error) {
+        console.error("Failed to parse realtime message", error);
+      }
+    };
+  }
+
+  private scheduleReconnect() {
+    if (this.reconnectTimer) {
+      return;
+    }
+    this.reconnectTimer = window.setTimeout(() => {
+      this.reconnectTimer = null;
+      if (this.failureCount >= 3) {
+        this.useSse = true;
+      }
+      this.connect();
+    }, RECONNECT_INTERVAL);
+  }
+
+  private openSse() {
+    if (this.eventSource) {
+      return;
+    }
+    const parsed = new URL(this.url);
+    parsed.protocol = parsed.protocol === "wss:" ? "https:" : "http:";
+    parsed.pathname = parsed.pathname.replace(/\/?ws$/, "/events");
+    const sseUrl = parsed.toString();
+    this.eventSource = new EventSource(sseUrl);
+    this.eventSource.onopen = (event) => {
+      this.failureCount = 0;
+      this.emitter.emit("open", event as unknown as Event);
+    };
+    this.eventSource.onerror = (event) => {
+      this.failureCount += 1;
+      this.emitter.emit("error", event as unknown as Event);
+      const closeEvent = new CloseEvent("close", {
+        wasClean: false,
+        code: 1006,
+        reason: "SSE connection error",
+      });
+      this.emitter.emit("close", closeEvent);
+      if (!this.manualClose) {
+        this.eventSource?.close();
+        this.eventSource = null;
+        this.scheduleReconnect();
+      }
+    };
+    this.eventSource.onmessage = (event) => {
+      try {
+        const payload = JSON.parse(event.data);
+        this.dispatchEvent(payload.event, payload.payload);
+        this.emitter.emit("message", payload);
+      } catch (error) {
+        console.error("Failed to parse SSE message", error);
+      }
+    };
+  }
+
+  private dispatchEvent(event: string, payload: any) {
+    const listeners = this.eventMap[event];
+    if (!listeners) return;
+    listeners.forEach((listener) => listener(payload));
+  }
+
+  onMessage(handler: Handler<RealtimeEvents["message"]>) {
+    this.emitter.on("message", handler);
+    return () => this.emitter.off("message", handler);
+  }
+
+  onOpen(handler: Handler<RealtimeEvents["open"]>) {
+    this.emitter.on("open", handler);
+    return () => this.emitter.off("open", handler);
+  }
+
+  onClose(handler: Handler<RealtimeEvents["close"]>) {
+    this.emitter.on("close", handler);
+    return () => this.emitter.off("close", handler);
+  }
+
+  onError(handler: Handler<RealtimeEvents["error"]>) {
+    this.emitter.on("error", handler);
+    return () => this.emitter.off("error", handler);
+  }
+
+  on(event: string, handler: Listener) {
+    if (!this.eventMap[event]) {
+      this.eventMap[event] = new Set();
+    }
+    this.eventMap[event].add(handler);
+    return () => this.off(event, handler);
+  }
+
+  off(event: string, handler: Listener) {
+    const listeners = this.eventMap[event];
+    if (!listeners) return;
+    listeners.delete(handler);
+    if (listeners.size === 0) {
+      delete this.eventMap[event];
+    }
+  }
+
+  reconnect() {
+    this.manualClose = false;
+    if (this.socket || this.eventSource) {
+      return;
+    }
+    this.connect();
+  }
+
+  close() {
+    this.manualClose = true;
+    this.failureCount = 0;
+    this.useSse = false;
+    if (this.socket) {
+      this.socket.close();
+      this.socket = null;
+    }
+    if (this.eventSource) {
+      this.eventSource.close();
+      this.eventSource = null;
+    }
+    if (this.reconnectTimer) {
+      window.clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+}
+
+const realtimeService = new RealtimeService();
+export default realtimeService;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,143 @@
+:root {
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #101319;
+  color: #f5f7fb;
+}
+
+body {
+  margin: 0;
+}
+
+.dashboard {
+  padding: 2rem;
+}
+
+.dashboard__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 2rem;
+}
+
+.status-indicator {
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  background: #2b2f3a;
+  color: #fff;
+  font-weight: 600;
+}
+
+.status-indicator.is-online {
+  background: #2ecc71;
+  color: #101319;
+}
+
+.status-indicator.is-offline {
+  background: #f39c12;
+}
+
+.dashboard__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.card {
+  background: rgba(24, 32, 44, 0.85);
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+}
+
+.card__header {
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.card__body {
+  padding: 1.5rem;
+}
+
+.metric {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.metric__label {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.metric__value {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.device-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.device {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: rgba(34, 45, 61, 0.9);
+}
+
+.status--success {
+  border-left: 4px solid #2ecc71;
+}
+
+.status--danger {
+  border-left: 4px solid #e74c3c;
+}
+
+.status--warning {
+  border-left: 4px solid #f1c40f;
+}
+
+.status--info {
+  border-left: 4px solid #3498db;
+}
+
+.alarm-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.alarm {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: rgba(34, 45, 61, 0.85);
+}
+
+.alarm--critical {
+  border-left: 4px solid #e74c3c;
+}
+
+.alarm--warning {
+  border-left: 4px solid #f1c40f;
+}
+
+.alarm--info {
+  border-left: 4px solid #3498db;
+}
+
+.alarm__title {
+  font-weight: 600;
+}
+
+.alarm__message {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.alarm__time {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.6);
+  margin-top: 0.5rem;
+}

--- a/frontend/src/types/realtime.ts
+++ b/frontend/src/types/realtime.ts
@@ -1,0 +1,32 @@
+export interface EnvironmentReading {
+  id: number;
+  location: string;
+  temperature: number;
+  humidity: number;
+  air_quality_index: number;
+  created_at: string;
+}
+
+export interface DeviceStatus {
+  id: number;
+  device_id: string;
+  name: string;
+  status: string;
+  meta: Record<string, any>;
+  updated_at: string;
+}
+
+export interface AlarmEvent {
+  id: number;
+  code: string;
+  message: string;
+  severity: "info" | "warning" | "critical";
+  device_id?: string | null;
+  created_at: string;
+}
+
+export interface RealtimeMessage<T = any> {
+  event: string;
+  payload: T;
+  created_at: string;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: "0.0.0.0",
+    port: 5173,
+    proxy: {
+      "/api": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+        ws: true
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add a FastAPI backend with REST, WebSocket, and SSE endpoints plus async SQLite persistence
- implement data ingestion helpers with simulation workers that broadcast realtime events
- create a Vite + React dashboard with a reusable realtime service and live-updating widgets

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68cd07eb630c8321b281daa884b2c407