### PR TITLE
Add comprehensive testing and CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+
+      - name: Run backend tests
+        run: |
+          cd backend
+          pytest
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm install
+        working-directory: frontend
+
+      - name: Frontend type check
+        run: npm run lint
+        working-directory: frontend
+
+      - name: Frontend unit tests
+        run: npm run test:run
+        working-directory: frontend
+        env:
+          CI: "1"
+
+      - name: Frontend build
+        run: npm run build
+        working-directory: frontend
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+        working-directory: frontend
+
+      - name: End-to-end tests
+        run: npm run test:e2e
+        working-directory: frontend
+        env:
+          CI: "1"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,47 @@ The dev server proxies API calls to `http://localhost:8000` by default.
 * When the backend starts, a simulation worker pushes demo data every few seconds. This keeps the dashboard lively in demos.
 * The backend uses SQLite via SQLAlchemy's async engine. Database schema is created automatically on startup.
 * Realtime broadcasts are logged in the `realtime_dispatch_log` table for traceability.
+
+## Testing
+
+The repository ships with a full testing stack covering the backend, frontend and end-to-end flows. All commands below assume the repository root as the working directory.
+
+### Backend unit & integration tests
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+pytest
+```
+
+These tests exercise the async data ingestion pipeline, API endpoints and the simulation-mode switch using an isolated SQLite database.
+
+### Frontend component tests
+
+```bash
+cd frontend
+npm install
+npm run test:run
+```
+
+Vitest together with Testing Library validates component state management, realtime event subscriptions and dashboard wiring.
+
+### End-to-end tests
+
+```bash
+cd frontend
+npm install
+npx playwright install --with-deps
+npm run test:e2e
+```
+
+Playwright boots the Vite dev server, stubs backend APIs and verifies the dashboard’s critical user journeys including realtime mode transitions.
+
+### Continuous integration
+
+A GitHub Actions workflow (`.github/workflows/ci.yml`) runs linting, backend pytest, frontend unit tests, the production build and Playwright end-to-end checks on every push. The workflow definition can be used as a template for other CI platforms.
 =======
 # IoT Board Backend
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,6 @@ python-multipart==0.0.9
 SQLAlchemy>=2.0
 alembic>=1.13
 psycopg2-binary>=2.9
+pytest==8.2.2
+pytest-asyncio==0.23.7
+httpx==0.27.0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from typing import Callable
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from app import db as db_module
+from app.config import get_settings
+from app.db import Base, get_async_session, get_engine
+from app.main import create_app
+
+
+@pytest.fixture(autouse=True)
+def clear_settings_cache() -> Iterator[None]:
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture()
+def configure_test_database(tmp_path, monkeypatch) -> Iterator[None]:
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("IOT_BOARD_DATABASE_URL", f"sqlite+aiosqlite:///{db_path}")
+    monkeypatch.setenv("IOT_BOARD_SIMULATION_MODE", "false")
+    get_settings.cache_clear()
+    db_module._engine = None
+    db_module._session_factory = None
+    yield
+    db_module._engine = None
+    db_module._session_factory = None
+
+
+async def _create_schema() -> None:
+    engine = get_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+        await conn.run_sync(Base.metadata.create_all)
+
+
+async def _drop_schema() -> None:
+    engine = get_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest.fixture()
+def prepare_database(configure_test_database) -> Iterator[None]:
+    asyncio.run(_create_schema())
+    yield
+    asyncio.run(_drop_schema())
+
+
+@pytest.fixture()
+def app(prepare_database):
+    return create_app()
+
+
+@pytest.fixture()
+def client(app) -> Iterator[TestClient]:
+    with TestClient(app) as instance:
+        yield instance
+
+
+@pytest.fixture()
+def list_entities() -> Callable[[type], list[object]]:
+    async def _list(model: type) -> list[object]:
+        async with get_async_session() as session:
+            result = await session.execute(select(model))
+            return list(result.scalars())
+
+    def wrapper(model: type) -> list[object]:
+        return asyncio.run(_list(model))
+
+    return wrapper

--- a/backend/tests/test_data_ingestion.py
+++ b/backend/tests/test_data_ingestion.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import asyncio
+
+from app import data_ingestion
+from app.models import DeviceStatus, EnvironmentReading, RealTimeDispatchLog
+from app.realtime import manager
+from app.schemas import BroadcastEnvelope
+
+
+def test_handle_environment_update_persists_and_broadcasts(list_entities, monkeypatch):
+    captured: list[BroadcastEnvelope] = []
+
+    async def fake_broadcast(envelope: BroadcastEnvelope) -> None:
+        captured.append(envelope)
+
+    monkeypatch.setattr(manager, "broadcast", fake_broadcast)
+
+    payload = {
+        "location": "lab",
+        "temperature": 21.5,
+        "humidity": 55.2,
+        "air_quality_index": 42.0,
+    }
+
+    asyncio.run(data_ingestion.handle_environment_update(payload))
+
+    readings = list_entities(EnvironmentReading)
+    logs = list_entities(RealTimeDispatchLog)
+
+    assert len(readings) == 1
+    assert readings[0].location == "lab"
+    assert len(logs) == 1
+    assert logs[0].event_type == "environment.update"
+    assert captured and captured[0].event == "environment.update"
+
+
+def test_handle_device_status_upserts_and_broadcasts(list_entities, monkeypatch):
+    captured: list[BroadcastEnvelope] = []
+
+    async def fake_broadcast(envelope: BroadcastEnvelope) -> None:
+        captured.append(envelope)
+
+    monkeypatch.setattr(manager, "broadcast", fake_broadcast)
+
+    first = {
+        "device_id": "sensor-1",
+        "name": "Sensor",
+        "status": "online",
+        "meta": {"battery": 95},
+    }
+
+    second = {
+        "device_id": "sensor-1",
+        "name": "Sensor",
+        "status": "offline",
+        "meta": {"battery": 10},
+    }
+
+    asyncio.run(data_ingestion.handle_device_status(first))
+    asyncio.run(data_ingestion.handle_device_status(second))
+
+    devices = list_entities(DeviceStatus)
+    logs = list_entities(RealTimeDispatchLog)
+
+    assert len(devices) == 1
+    assert devices[0].status == "offline"
+    assert devices[0].meta == {"battery": 10}
+    assert len(logs) == 2
+    assert captured[-1].event == "device.update"
+
+
+def test_start_background_tasks_respects_simulation_mode(monkeypatch):
+    monkeypatch.setenv("IOT_BOARD_SIMULATION_MODE", "false")
+    data_ingestion.get_settings.cache_clear()
+
+    def forbidden_create_task(_coro):
+        raise AssertionError("Simulation worker should not start when disabled")
+
+    monkeypatch.setattr(asyncio, "create_task", forbidden_create_task)
+
+    async def runner() -> None:
+        shutdown = await data_ingestion.start_background_tasks()
+        await shutdown()
+
+    asyncio.run(runner())
+
+
+def test_start_background_tasks_launches_simulation(monkeypatch):
+    monkeypatch.setenv("IOT_BOARD_SIMULATION_MODE", "true")
+    data_ingestion.get_settings.cache_clear()
+
+    started = asyncio.Event()
+
+    async def fake_worker(stop_event: asyncio.Event) -> None:
+        started.set()
+        await stop_event.wait()
+
+    monkeypatch.setattr(data_ingestion, "simulation_worker", fake_worker)
+
+    created_tasks: list[asyncio.Task[None]] = []
+    original_create_task = asyncio.create_task
+
+    def tracking_create_task(coro):
+        task = original_create_task(coro)
+        created_tasks.append(task)
+        return task
+
+    monkeypatch.setattr(asyncio, "create_task", tracking_create_task)
+
+    async def runner() -> None:
+        shutdown = await data_ingestion.start_background_tasks()
+        await asyncio.wait_for(started.wait(), timeout=1)
+        await shutdown()
+
+    asyncio.run(runner())
+
+    assert len(created_tasks) == 1
+    assert all(task.cancelled() or task.done() for task in created_tasks)

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from app.models import AlarmEvent, DeviceStatus, EnvironmentReading
+
+
+def test_environment_endpoints(client, list_entities):
+    payload = {
+        "location": "hq",
+        "temperature": 24.3,
+        "humidity": 48.1,
+        "air_quality_index": 37.2,
+    }
+
+    response = client.post("/api/environment", json=payload)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["location"] == "hq"
+
+    listing = client.get("/api/environment", params={"limit": 10})
+    assert listing.status_code == 200
+    items = listing.json()
+    assert len(items) == 1
+    assert items[0]["temperature"] == payload["temperature"]
+
+    readings = list_entities(EnvironmentReading)
+    assert len(readings) == 1
+
+
+def test_device_upsert_and_listing(client, list_entities):
+    first = {
+        "device_id": "gateway-1",
+        "name": "Gateway",
+        "status": "online",
+        "meta": {"ip": "10.0.0.1"},
+    }
+
+    second = {
+        "device_id": "gateway-1",
+        "name": "Gateway",
+        "status": "maintenance",
+        "meta": {"ip": "10.0.0.1", "firmware": "1.2.0"},
+    }
+
+    created = client.post("/api/devices", json=first)
+    assert created.status_code == 200
+
+    updated = client.post("/api/devices", json=second)
+    assert updated.status_code == 200
+    data = updated.json()
+    assert data["status"] == "maintenance"
+    assert data["meta"]["firmware"] == "1.2.0"
+
+    listing = client.get("/api/devices")
+    assert listing.status_code == 200
+    entries = listing.json()
+    assert len(entries) == 1
+    assert entries[0]["status"] == "maintenance"
+
+    devices = list_entities(DeviceStatus)
+    assert len(devices) == 1
+
+
+def test_alarm_creation(client, list_entities):
+    payload = {
+        "code": "DEVICE_OFFLINE",
+        "message": "Sensor offline",
+        "severity": "critical",
+        "device_id": "sensor-9",
+    }
+
+    response = client.post("/api/alarms", json=payload)
+    assert response.status_code == 200
+    alarm = response.json()
+    assert alarm["code"] == "DEVICE_OFFLINE"
+
+    listing = client.get("/api/alarms")
+    assert listing.status_code == 200
+    alarms = listing.json()
+    assert len(alarms) == 1
+
+    stored = list_entities(AlarmEvent)
+    assert len(stored) == 1

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from "@playwright/test";
+
+const environmentPayload = [
+  {
+    id: 1,
+    location: "demo",
+    temperature: 22.1,
+    humidity: 44.5,
+    air_quality_index: 31,
+    created_at: new Date().toISOString()
+  }
+];
+
+const devicePayload = [
+  {
+    id: 1,
+    device_id: "demo-device",
+    name: "Demo Sensor",
+    status: "online",
+    meta: {},
+    updated_at: new Date().toISOString()
+  }
+];
+
+const alarmPayload: any[] = [];
+
+test("dashboard renders core flows with realtime updates", async ({ page }) => {
+  await page.route("**/api/environment", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(environmentPayload)
+    });
+  });
+  await page.route("**/api/devices", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(devicePayload)
+    });
+  });
+  await page.route("**/api/alarms", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(alarmPayload)
+    });
+  });
+
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { name: "IoT Command Center" })).toBeVisible();
+  await expect(page.getByText("Demo Sensor")).toBeVisible();
+  await expect(page.getByText("No alarms")).toBeVisible();
+  await expect(page.getByText("Connecting...")).toBeVisible();
+
+  await page.evaluate(() => {
+    window.__iotRealtimeTestHooks?.triggerOpen();
+  });
+  await expect(page.getByText("Realtime Connected")).toBeVisible();
+
+  await page.evaluate(() => {
+    window.__iotRealtimeTestHooks?.emit("device.update", {
+      id: 2,
+      device_id: "demo-device",
+      name: "Demo Sensor",
+      status: "maintenance",
+      meta: { firmware: "2.0.0" },
+      updated_at: new Date().toISOString()
+    });
+  });
+  await expect(page.getByText("maintenance")).toBeVisible();
+
+  const alarmEvent = {
+    id: 3,
+    code: "DEVICE_OFFLINE",
+    message: "Sensor disconnected",
+    severity: "warning",
+    device_id: "demo-device",
+    created_at: new Date().toISOString()
+  };
+  await page.evaluate((event) => {
+    window.__iotRealtimeTestHooks?.emit("alarm.raise", event);
+  }, alarmEvent);
+  await expect(page.getByText("DEVICE_OFFLINE")).toBeVisible();
+
+  await page.evaluate(() => {
+    window.__iotRealtimeTestHooks?.triggerClose();
+  });
+  await expect(page.getByText("Connecting...")).toBeVisible();
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,11 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -17,7 +21,15 @@
     "@types/react": "^18.2.22",
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react": "^4.2.1",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/testing-library__jest-dom": "^5.14.9",
+    "@vitest/coverage-v8": "^1.6.0",
+    "@playwright/test": "^1.44.0",
+    "jsdom": "^24.0.0",
     "typescript": "^5.3.3",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 60_000,
+  retries: process.env.CI ? 1 : 0,
+  use: {
+    baseURL: "http://127.0.0.1:5173",
+    trace: "on-first-retry",
+    browserName: "chromium",
+    viewport: { width: 1280, height: 720 }
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] }
+    }
+  ],
+  webServer: {
+    command: "npm run dev -- --host",
+    port: 5173,
+    reuseExistingServer: !process.env.CI,
+    cwd: "./frontend"
+  }
+});

--- a/frontend/src/components/__tests__/DeviceStatusBoard.test.tsx
+++ b/frontend/src/components/__tests__/DeviceStatusBoard.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import DeviceStatusBoard from "../DeviceStatusBoard";
+import type { DeviceStatus } from "../../types/realtime";
+
+const eventCallbacks: Record<string, ((payload: unknown) => void)[]> = {};
+
+vi.mock("../../services/realtime", () => {
+  return {
+    default: {
+      on: vi.fn((event: string, handler: (payload: unknown) => void) => {
+        if (!eventCallbacks[event]) {
+          eventCallbacks[event] = [];
+        }
+        eventCallbacks[event].push(handler);
+        return () => {
+          eventCallbacks[event] = eventCallbacks[event].filter((cb) => cb !== handler);
+        };
+      })
+    }
+  };
+});
+
+describe("DeviceStatusBoard", () => {
+  beforeEach(() => {
+    Object.keys(eventCallbacks).forEach((key) => delete eventCallbacks[key]);
+  });
+
+  it("renders initial devices and reacts to realtime updates", async () => {
+    const initial: DeviceStatus = {
+      id: 1,
+      device_id: "edge-1",
+      name: "Gateway",
+      status: "online",
+      meta: {},
+      updated_at: new Date().toISOString()
+    };
+
+    render(<DeviceStatusBoard initialDevices={[initial]} />);
+
+    expect(screen.getByText("Gateway")).toBeInTheDocument();
+    expect(screen.getByText("online")).toBeInTheDocument();
+
+    const update: DeviceStatus = {
+      ...initial,
+      status: "offline"
+    };
+
+    const listeners = eventCallbacks["device.update"] ?? [];
+    listeners.forEach((listener) => listener(update));
+
+    await waitFor(() => {
+      const status = screen.getByText("offline");
+      expect(status).toBeInTheDocument();
+      const container = status.closest(".device");
+      expect(container).toHaveClass("status--danger");
+    });
+  });
+});

--- a/frontend/src/components/__tests__/EnvironmentMonitor.test.tsx
+++ b/frontend/src/components/__tests__/EnvironmentMonitor.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import EnvironmentMonitor from "../EnvironmentMonitor";
+import type { EnvironmentReading } from "../../types/realtime";
+
+const eventCallbacks: Record<string, ((payload: unknown) => void)[]> = {};
+
+vi.mock("../../services/realtime", () => {
+  return {
+    default: {
+      on: vi.fn((event: string, handler: (payload: unknown) => void) => {
+        if (!eventCallbacks[event]) {
+          eventCallbacks[event] = [];
+        }
+        eventCallbacks[event].push(handler);
+        return () => {
+          eventCallbacks[event] = eventCallbacks[event].filter((cb) => cb !== handler);
+        };
+      })
+    }
+  };
+});
+
+describe("EnvironmentMonitor", () => {
+  beforeEach(() => {
+    Object.keys(eventCallbacks).forEach((key) => delete eventCallbacks[key]);
+  });
+
+  it("renders the latest reading and updates on realtime events", async () => {
+    const initial: EnvironmentReading = {
+      id: 1,
+      location: "lab",
+      temperature: 20.2,
+      humidity: 40.5,
+      air_quality_index: 35,
+      created_at: new Date().toISOString()
+    };
+
+    render(<EnvironmentMonitor initialReadings={[initial]} />);
+
+    expect(screen.getByText(/20\.2°C/)).toBeInTheDocument();
+    expect(screen.getByText(/40\.5%/)).toBeInTheDocument();
+    expect(screen.getByText(/35/)).toBeInTheDocument();
+
+    const update: EnvironmentReading = {
+      id: 2,
+      location: "lab",
+      temperature: 23.5,
+      humidity: 50.1,
+      air_quality_index: 30,
+      created_at: new Date().toISOString()
+    };
+
+    const listeners = eventCallbacks["environment.update"] ?? [];
+    listeners.forEach((listener) => listener(update));
+
+    await waitFor(() => {
+      expect(screen.getByText(/23\.5°C/)).toBeInTheDocument();
+      expect(screen.getByText(/50\.1%/)).toBeInTheDocument();
+      expect(screen.getByText(/30/)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/__tests__/Dashboard.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import DashboardPage from "../Dashboard";
+import type { AlarmEvent, DeviceStatus, EnvironmentReading } from "../../types/realtime";
+
+const realtimeEvents: Record<string, ((payload: unknown) => void)[]> = {};
+const openHandlers: Set<(event: Event) => void> = new Set();
+const closeHandlers: Set<(event: CloseEvent) => void> = new Set();
+
+vi.mock("../../services/realtime", () => ({
+  default: {
+    on: vi.fn((event: string, handler: (payload: unknown) => void) => {
+      if (!realtimeEvents[event]) {
+        realtimeEvents[event] = [];
+      }
+      realtimeEvents[event].push(handler);
+      return () => {
+        realtimeEvents[event] = realtimeEvents[event].filter((cb) => cb !== handler);
+      };
+    }),
+    onOpen: vi.fn((handler: (event: Event) => void) => {
+      openHandlers.add(handler);
+      return () => openHandlers.delete(handler);
+    }),
+    onClose: vi.fn((handler: (event: CloseEvent) => void) => {
+      closeHandlers.add(handler);
+      return () => closeHandlers.delete(handler);
+    }),
+    onError: vi.fn((handler: (event: Event) => void) => {
+      return () => {
+        // no-op for tests
+      };
+    })
+  }
+}));
+
+describe("DashboardPage", () => {
+  const environment: EnvironmentReading[] = [
+    {
+      id: 1,
+      location: "field",
+      temperature: 25,
+      humidity: 45,
+      air_quality_index: 32,
+      created_at: new Date().toISOString()
+    }
+  ];
+  const devices: DeviceStatus[] = [
+    {
+      id: 1,
+      device_id: "node-1",
+      name: "Edge Node",
+      status: "online",
+      meta: {},
+      updated_at: new Date().toISOString()
+    }
+  ];
+  const alarms: AlarmEvent[] = [
+    {
+      id: 1,
+      code: "DEVICE_OFFLINE",
+      message: "Node lost connectivity",
+      severity: "warning",
+      device_id: "node-1",
+      created_at: new Date().toISOString()
+    }
+  ];
+
+  beforeEach(() => {
+    Object.keys(realtimeEvents).forEach((key) => delete realtimeEvents[key]);
+    openHandlers.clear();
+    closeHandlers.clear();
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo) => {
+      if (typeof input === "string" && input.endsWith("/api/environment")) {
+        return new Response(JSON.stringify(environment), {
+          status: 200,
+          headers: { "Content-Type": "application/json" }
+        });
+      }
+      if (typeof input === "string" && input.endsWith("/api/devices")) {
+        return new Response(JSON.stringify(devices), {
+          status: 200,
+          headers: { "Content-Type": "application/json" }
+        });
+      }
+      if (typeof input === "string" && input.endsWith("/api/alarms")) {
+        return new Response(JSON.stringify(alarms), {
+          status: 200,
+          headers: { "Content-Type": "application/json" }
+        });
+      }
+      throw new Error(`Unexpected fetch ${input}`);
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loads initial data and reacts to realtime connection events", async () => {
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Edge Node")).toBeInTheDocument();
+      expect(screen.getByText("DEVICE_OFFLINE")).toBeInTheDocument();
+      expect(screen.queryByText("Realtime Connected")).not.toBeInTheDocument();
+    });
+
+    openHandlers.forEach((handler) => handler(new Event("open")));
+
+    await waitFor(() => {
+      expect(screen.getByText("Realtime Connected")).toBeInTheDocument();
+    });
+
+    const newAlarm: AlarmEvent = {
+      id: 2,
+      code: "TEMP_HIGH",
+      message: "Temperature exceeded threshold",
+      severity: "critical",
+      device_id: "node-1",
+      created_at: new Date().toISOString()
+    };
+
+    const listeners = realtimeEvents["alarm.raise"] ?? [];
+    listeners.forEach((listener) => listener(newAlarm));
+
+    await waitFor(() => {
+      expect(screen.getByText("TEMP_HIGH")).toBeInTheDocument();
+    });
+
+    const closeEvent = typeof CloseEvent !== "undefined"
+      ? new CloseEvent("close")
+      : (new Event("close") as CloseEvent);
+    closeHandlers.forEach((handler) => handler(closeEvent));
+
+    await waitFor(() => {
+      expect(screen.getByText("Connecting...")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/frontend/src/types/global.d.ts
+++ b/frontend/src/types/global.d.ts
@@ -1,0 +1,12 @@
+declare global {
+  interface Window {
+    __iotRealtimeTestHooks?: {
+      emit(event: string, payload: any): void;
+      triggerOpen(): void;
+      triggerClose(): void;
+      triggerError(): void;
+    };
+  }
+}
+
+export {};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -8,7 +8,11 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "types": ["vite/client"]
+    "types": [
+      "vite/client",
+      "vitest/globals",
+      "@testing-library/jest-dom"
+    ]
   },
   "include": ["src"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,5 +13,15 @@ export default defineConfig({
         ws: true
       }
     }
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: "./src/setupTests.ts",
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      reportsDirectory: "./coverage"
+    }
   }
 });


### PR DESCRIPTION
## Summary
- add backend unit and integration tests covering ingestion handlers, API endpoints, and simulation controls
- configure frontend Vitest suite with Testing Library plus Playwright e2e scenario and supporting test hooks
- wire up GitHub Actions workflow to run linting, backend pytest, frontend unit tests, build, and Playwright checks while documenting test commands in the README

## Testing
- `pytest backend/tests` *(fails locally: missing fastapi dependency in offline environment)*
- `npm run lint` *(fails locally: npm packages unavailable in offline environment)*
- `npm run test:run` *(fails locally: npm packages unavailable in offline environment)*
- `npm run test:e2e` *(fails locally: npm packages unavailable in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd07ed809c832188632e64e484e23e